### PR TITLE
create endpoint cloud-init lxd

### DIFF
--- a/backend/src/core/container.py
+++ b/backend/src/core/container.py
@@ -8,6 +8,7 @@ from .workers.billing import BillingWorker
 from .service.user import UserService
 from .service.instance import InstanceService
 from .service.subscription import SubscriptionService
+from .service.lxd_cluster import LXDClusterService
 from .sql.operations import *
 
 
@@ -50,6 +51,10 @@ class AppContainer(containers.DeclarativeContainer):
         InstanceService,
         subscription_service=subscription_service,
         instance_opr=instance_opr,
+        lxd_client=lxd_client
+    )
+    lxd_cluster_service = providers.Factory(
+        LXDClusterService,
         lxd_client=lxd_client
     )
 

--- a/backend/src/core/main.py
+++ b/backend/src/core/main.py
@@ -25,7 +25,7 @@ modules = [
     # Router modules
     user,
     instance,
-    lxd_cluster
+    lxd_cluster 
 ]
 for module in modules:
     container.wire(modules=[module])

--- a/backend/src/core/main.py
+++ b/backend/src/core/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routers import user, instance
+from .routers import user, instance, lxd_cluster
 from .utils.logging import logger, configure_logging
 from .startup import lifespan
 from .container import AppContainer
@@ -24,7 +24,8 @@ app.state.container = container
 modules = [
     # Router modules
     user,
-    instance
+    instance,
+    lxd_cluster
 ]
 for module in modules:
     container.wire(modules=[module])
@@ -69,6 +70,7 @@ app.add_middleware(
 
 app.include_router(user.router)
 app.include_router(instance.router)
+app.include_router(lxd_cluster.router)
 
 @app.get("/", tags=["root"])
 async def root():

--- a/backend/src/core/models/lxd_cluster.py
+++ b/backend/src/core/models/lxd_cluster.py
@@ -1,0 +1,13 @@
+from .base_model import BaseModel
+
+class CreateJoinTokenRequest(BaseModel):
+    server_name: str
+    
+class CreateJoinTokenResponse(BaseModel):
+    join_token: str
+    
+class AddMemberRequest(BaseModel):
+    server_name: str
+
+class AddMemberResponse(BaseModel):
+    success: bool

--- a/backend/src/core/routers/lxd_cluster.py
+++ b/backend/src/core/routers/lxd_cluster.py
@@ -1,31 +1,35 @@
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Request
+from dependency_injector.wiring import Provide, inject
 
-from ..models.lxd_cluster import AddMemberResponse, CreateJoinTokenResponse
+from ..models.lxd_cluster import AddMemberRequest, CreateJoinTokenRequest, CreateJoinTokenResponse
 from ..service.lxd_cluster import LXDClusterService
-
+from ..container import AppContainer
 
 router = APIRouter(
-    prefix="internal/cluster",
-    tags=["user"],
+    prefix="/internal/cluster",
+    tags=["cluster"],
 )
 
 @router.post(
-    "create_token",
+    "/create_token",
     response_model=CreateJoinTokenResponse
 )
+@inject
 async def create_join_token(
-    request: Request,
-    lxd_cluster_service: LXDClusterService = Depends()
+    request: CreateJoinTokenRequest,
+    lxd_cluster_service: LXDClusterService = Depends(Provide[AppContainer.lxd_cluster_service])
 ):
-    return await lxd_cluster_service.create_lxd_cluster_join_token(request)
-  
+    token = await lxd_cluster_service.create_lxd_cluster_join_token(request)
+    return token
+
 @router.post(
-    "add_member",
-    response_model=AddMemberResponse
+    "/add_member",
+    response_model=AddMemberRequest
 )
+@inject
 async def add_member(
     request: Request,
-    lxd_cluster_service: LXDClusterService = Depends()
+    lxd_cluster_service: LXDClusterService = Depends(Provide[AppContainer.lxd_cluster_service])
 ):
     return await lxd_cluster_service.add_member_to_lxd_cluster_group(request)
   

--- a/backend/src/core/routers/lxd_cluster.py
+++ b/backend/src/core/routers/lxd_cluster.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, Request, Response
+
+from ..models.lxd_cluster import AddMemberResponse, CreateJoinTokenResponse
+from ..service.lxd_cluster import LXDClusterService
+
+
+router = APIRouter(
+    prefix="internal/cluster",
+    tags=["user"],
+)
+
+@router.post(
+    "create_token",
+    response_model=CreateJoinTokenResponse
+)
+async def create_join_token(
+    request: Request,
+    lxd_cluster_service: LXDClusterService = Depends()
+):
+    return await lxd_cluster_service.create_lxd_cluster_join_token(request)
+  
+@router.post(
+    "add_member",
+    response_model=AddMemberResponse
+)
+async def add_member(
+    request: Request,
+    lxd_cluster_service: LXDClusterService = Depends()
+):
+    return await lxd_cluster_service.add_member_to_lxd_cluster_group(request)
+  
+

--- a/backend/src/core/routers/lxd_cluster.py
+++ b/backend/src/core/routers/lxd_cluster.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Request
 from dependency_injector.wiring import Provide, inject
 
-from ..models.lxd_cluster import AddMemberRequest, CreateJoinTokenRequest, CreateJoinTokenResponse
+from ..models.lxd_cluster import AddMemberRequest, AddMemberResponse, CreateJoinTokenRequest, CreateJoinTokenResponse
 from ..service.lxd_cluster import LXDClusterService
 from ..container import AppContainer
 
@@ -24,11 +24,11 @@ async def create_join_token(
 
 @router.post(
     "/add_member",
-    response_model=AddMemberRequest
+    response_model=AddMemberResponse
 )
 @inject
 async def add_member(
-    request: Request,
+    request: AddMemberRequest,
     lxd_cluster_service: LXDClusterService = Depends(Provide[AppContainer.lxd_cluster_service])
 ):
     return await lxd_cluster_service.add_member_to_lxd_cluster_group(request)

--- a/backend/src/core/service/clients/lxd.py
+++ b/backend/src/core/service/clients/lxd.py
@@ -94,6 +94,12 @@ class LXDClient(BaseInstanceClient[models.Instance]):
         finally:
             await self.lxd_ws_manager.remove_session(instance_identifier.name)
 
+    def create_lxd_cluster_join_token(self, server_name: str) -> str:
+        return self.lxd_manager.create_cluster_join_token(server_name)
+      
+    def add_member_to_lxd_cluster_group(self, server_name: str) -> bool:
+        return self.lxd_manager.add_member_to_cluster_group(server_name)
+
     def __to_instance_create_config(self, instance_create: InstanceCreateRequest) -> dict:
         return {
             "device": {

--- a/backend/src/core/service/lxd_cluster.py
+++ b/backend/src/core/service/lxd_cluster.py
@@ -1,0 +1,23 @@
+from .clients.base_instance_client import BaseInstanceClient
+from .clients.lxd import LXDClient
+from fastapi import Depends
+from ..models.lxd_cluster import CreateJoinTokenRequest, CreateJoinTokenResponse, AddMemberResponse
+
+
+class LXDClusterService:
+    def __init__(
+        self, 
+        lxd_client: LXDClient = Depends(LXDClient.get_client)
+    ):
+        self.lxd_client = lxd_client
+        
+    async def create_lxd_cluster_join_token(self, request: CreateJoinTokenRequest) -> str:
+        token = await self.lxd_client.create_lxd_cluster_join_token(request.server_name)
+        return CreateJoinTokenResponse(token=token)
+      
+    async def add_member_to_lxd_cluster_group(self, request: AddMemberResponse) -> bool:
+        add_result = await self.lxd_client.add_member_to_lxd_cluster_group(request.server_name)
+        return AddMemberResponse(result=add_result)
+      
+    
+    

--- a/backend/src/core/service/lxd_cluster.py
+++ b/backend/src/core/service/lxd_cluster.py
@@ -17,7 +17,7 @@ class LXDClusterService:
       
     async def add_member_to_lxd_cluster_group(self, request: AddMemberRequest) -> AddMemberResponse:
         add_result = self.lxd_client.add_member_to_lxd_cluster_group(request.server_name)
-        return AddMemberResponse(result=add_result)
+        return AddMemberResponse(success=add_result)
       
     
     

--- a/backend/src/core/service/lxd_cluster.py
+++ b/backend/src/core/service/lxd_cluster.py
@@ -1,22 +1,22 @@
 from .clients.base_instance_client import BaseInstanceClient
 from .clients.lxd import LXDClient
 from fastapi import Depends
-from ..models.lxd_cluster import CreateJoinTokenRequest, CreateJoinTokenResponse, AddMemberResponse
+from ..models.lxd_cluster import CreateJoinTokenRequest, CreateJoinTokenResponse, AddMemberResponse, AddMemberRequest
 
 
 class LXDClusterService:
     def __init__(
         self, 
-        lxd_client: LXDClient = Depends(LXDClient.get_client)
+        lxd_client: LXDClient
     ):
         self.lxd_client = lxd_client
         
-    async def create_lxd_cluster_join_token(self, request: CreateJoinTokenRequest) -> str:
-        token = await self.lxd_client.create_lxd_cluster_join_token(request.server_name)
-        return CreateJoinTokenResponse(token=token)
+    async def create_lxd_cluster_join_token(self, request: CreateJoinTokenRequest) -> CreateJoinTokenResponse:
+        token = self.lxd_client.create_lxd_cluster_join_token(request.server_name)
+        return CreateJoinTokenResponse(join_token=token)
       
-    async def add_member_to_lxd_cluster_group(self, request: AddMemberResponse) -> bool:
-        add_result = await self.lxd_client.add_member_to_lxd_cluster_group(request.server_name)
+    async def add_member_to_lxd_cluster_group(self, request: AddMemberRequest) -> AddMemberResponse:
+        add_result = self.lxd_client.add_member_to_lxd_cluster_group(request.server_name)
         return AddMemberResponse(result=add_result)
       
     

--- a/backend/src/infra/managers/lxd.py
+++ b/backend/src/infra/managers/lxd.py
@@ -243,14 +243,12 @@ class LXDManager:
                 json=server
             ).json()
             
-            logger.info("Create cluster join token request: %s", token_request)
 
             # Response from calling the API consist of raw data that needed to be turn into base64
             # Response structure: https://documentation.ubuntu.com/lxd/en/latest/api/#/cluster/cluster_members_post
             # Join token structure: https://github.com/canonical/lxd/blob/main/shared/api/cluster.go#L108
             response = token_request['metadata']['metadata']
             
-            logger.info(f"Create cluster join token response: {response}")
 
             join_token_object = {
                 "server_name": response["serverName"],

--- a/backend/src/infra/managers/lxd.py
+++ b/backend/src/infra/managers/lxd.py
@@ -266,7 +266,7 @@ class LXDManager:
             raise LXDManagerException(f"Failed to create cluster join token: {str(e)}")
     
     @_ensure_connected()
-    def add_member_to_cluster_group(self, server_name: str, group: str = "resource") -> bool:
+    def add_member_to_cluster_group(self, server_name: str, group: str = "cloudboi-resource") -> bool:
         try:
             # Check if server exists
             all_members = self.get_all_cluster_members()
@@ -275,8 +275,8 @@ class LXDManager:
                 raise LXDManagerException(f"Server '{server_name}' not found in cluster members")
           
             # Get current group configuration
-            current_group_request = self.client.api.cluster.group[group].get()
-            current_group = current_group_request.json().metadata
+            current_group_request = self.client.api.cluster.groups[group].get()
+            current_group = current_group_request.json()['metadata']
             
             updated_group = {
               "description": current_group["description"],
@@ -286,7 +286,7 @@ class LXDManager:
             # Can only update the entire config of the group
             # https://documentation.ubuntu.com/lxd/en/latest/api/#/cluster-groups/cluster_group_patch
             
-            updated_group_request = self.client.api.cluster.group[group].put(
+            updated_group_request = self.client.api.cluster.groups[group].put(
                 json=updated_group
             )
             


### PR DESCRIPTION
Created endpoint for cloud init lxd member.

steps for member in cloudinit
-> install all prerequisite (lxd)
-> send request to fetch join token to create-join-token using hostname as server_name
-> proceed to lxd setup with join token
-> send request to join the resource cluster member