### PR TITLE
[Testing E2E] Add Test Scenario For Instance Create Page

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,16 +3,14 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-ENV DOCKER=true
-
 # Install make and git
 RUN apt-get update && apt-get install -y make git
 
 # Copy the application
 COPY . .
 
-# Install dependencies using make (with Docker flag)
-RUN make install
+# Install dependencies using make (with Docker flag explicitly set)
+RUN DOCKER=true make install
 
 # Run the backend using make (with Docker flag)
 CMD ["bash", "-c", "make ${APP_ENV}"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -17,16 +17,15 @@ else
 endif
 
 create-env:
-	test -d .venv || python -m venv .venv
-
-install:
 ifeq ($(DOCKER),true)
-	pip install -r requirements.txt
+	@echo "Skipping virtual environment creation in Docker"
 else
-	$(MAKE) create-env
+	test -d .venv || python -m venv .venv
+endif
+
+install: create-env
 	$(PIP) install pip-tools
 	$(PIP) install -r requirements.txt
-endif
 
 sync:
 	$(PIP_COMPILE) --output-file=requirements.txt requirements.in --strip-extras

--- a/backend/src/core/routers/user.py
+++ b/backend/src/core/routers/user.py
@@ -22,6 +22,18 @@ async def create_user(
     return await user_service.create_user(user_create)
 
 @router.post(
+    "/admin/create",
+    response_model=UserCreateResponse,
+    include_in_schema=False
+)
+@inject
+async def create_admin_user(
+    user_create: UserCreateRequest, 
+    user_service: UserService = Depends(Provide[AppContainer.user_service])
+):
+    return await user_service.create_admin_user(user_create)
+
+@router.post(
     "/login",
     response_model=UserLoginResponse,
 )

--- a/backend/src/core/service/instance.py
+++ b/backend/src/core/service/instance.py
@@ -186,15 +186,19 @@ class InstanceService:
         instance_name: Optional[str] = None
     ) -> InstanceControlResponse:
         from ..sql.operations.subscription import SubscriptionOperation
+        from ..sql.operations.transaction import TransactionOperation
         from ..container import AppContainer
         subscription_opr: SubscriptionOperation = AppContainer.subscription_opr()
+        transaction_opr: TransactionOperation = AppContainer.transaction_opr()
 
         instance = InstanceHelper.to_instance_upsert_model(
             await self.get_instance(instance_id=instance_id, instance_name=instance_name)
         )
 
         # Delete subscription
-        await subscription_opr.delete_subscription(instance_id=instance.instance_id)
+        result = await subscription_opr.delete_subscription(instance_id=instance.instance_id)
+        if result:
+            await transaction_opr.delete_subscription_transaction(subscription_id=result.subscription_id)
         
         # Delete instance in LXD
         await self.lxd_client.delete_instance(instance.hostname)

--- a/backend/src/core/service/subscription.py
+++ b/backend/src/core/service/subscription.py
@@ -24,7 +24,7 @@ class SubscriptionService:
         self.subscription_opr = subscription_opr
         self.transaction_opr = transaction_opr
 
-    async def create_subscription(self, user_id: uuid.UUID, instance_id: uuid.UUID, instance_plan: InstancePlan) -> None:
+    async def create_subscription(self, user_id: uuid.UUID, instance_id: uuid.UUID, instance_plan: InstancePlan) -> Transaction:
         """Create a new subscription and schedule the first payment transaction."""
         next_payment_date = DateTimeUtils.now_dt() + PAYMENT_INTERVAL
         next_expire_date = next_payment_date + EXPIRE_INTERVAL
@@ -45,7 +45,7 @@ class SubscriptionService:
             amount=monthly_cost
         )
 
-        await self.transaction_opr.upsert_transaction(transaction)
+        return await self.transaction_opr.upsert_transaction(transaction)
     
     async def next_subscription(self, transaction_old: Transaction) -> None:
         """Schedule the next subscription payment after a successful payment."""

--- a/backend/src/core/service/user.py
+++ b/backend/src/core/service/user.py
@@ -6,7 +6,7 @@ from ..sql.operations import UserOperation
 from .validators.user_validator import UserValidator
 from ..utils.token import TokenUtils
 from .helpers.user_helper import UserHelper
-from ..utils.permission import require_test_environment
+from ..utils.guard import require_test_environment
 
 class UserService:
     def __init__(

--- a/backend/src/core/utils/guard.py
+++ b/backend/src/core/utils/guard.py
@@ -1,0 +1,23 @@
+from fastapi import HTTPException, status
+from typing import Any, Tuple
+from .decorator import create_decorator
+from ..config import APP_ENV
+
+async def check_test_environment(self: Any, args: list, kwargs: dict, 
+                                exception_cls=HTTPException, **factory_kwargs) -> Tuple[list, dict]:
+    """
+    Check if the current user is in test environment.
+    """
+    if APP_ENV == "test":
+        return args, kwargs
+    
+    raise exception_cls(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Only allowed in test environment",
+    )
+
+# Create a decorator that doesn't require parameters
+require_test_environment = create_decorator(
+    precondition_check=check_test_environment,
+    skip_if_check_fails=False
+)()  # Note the additional parentheses to invoke the decorator factory

--- a/backend/src/core/utils/permission.py
+++ b/backend/src/core/utils/permission.py
@@ -231,19 +231,6 @@ async def check_account_ownership(self: Any, args: list, kwargs: dict,
         detail="You do not have permission to access this user account",
     )
 
-async def check_test_environment(self: Any, args: list, kwargs: dict, 
-                                exception_cls=HTTPException, **factory_kwargs) -> Tuple[list, dict]:
-    """
-    Check if the current user is in test environment.
-    """
-    if APP_ENV == "test":
-        return args, kwargs
-    
-    raise exception_cls(
-        status_code=status.HTTP_403_FORBIDDEN,
-        detail="Only allowed in test environment",
-    )
-
 
 # Create the permission decorators
 require_roles = create_decorator(
@@ -259,10 +246,5 @@ require_instance_ownership = create_decorator(
 # Decorator to check if current user owns the account or is admin
 require_account_ownership = create_decorator(
     precondition_check=check_account_ownership,
-    skip_if_check_fails=False
-)
-
-require_test_environment = create_decorator(
-    precondition_check=check_test_environment,
     skip_if_check_fails=False
 )

--- a/backend/src/core/utils/permission.py
+++ b/backend/src/core/utils/permission.py
@@ -8,6 +8,7 @@ from contextvars import ContextVar
 from .dependencies import user_session_ctx
 from .decorator import create_decorator
 from ..constants.user_const import UserRole
+from ..config import APP_ENV
 
 
 # Context variable to store worker context state
@@ -230,6 +231,19 @@ async def check_account_ownership(self: Any, args: list, kwargs: dict,
         detail="You do not have permission to access this user account",
     )
 
+async def check_test_environment(self: Any, args: list, kwargs: dict, 
+                                exception_cls=HTTPException, **factory_kwargs) -> Tuple[list, dict]:
+    """
+    Check if the current user is in test environment.
+    """
+    if APP_ENV == "test":
+        return args, kwargs
+    
+    raise exception_cls(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Only allowed in test environment",
+    )
+
 
 # Create the permission decorators
 require_roles = create_decorator(
@@ -245,5 +259,10 @@ require_instance_ownership = create_decorator(
 # Decorator to check if current user owns the account or is admin
 require_account_ownership = create_decorator(
     precondition_check=check_account_ownership,
+    skip_if_check_fails=False
+)
+
+require_test_environment = create_decorator(
+    precondition_check=check_test_environment,
     skip_if_check_fails=False
 )

--- a/backend/src/infra/config.py
+++ b/backend/src/infra/config.py
@@ -1,10 +1,11 @@
 import os
+from ..core.config import APP_ENV
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 CERT_DIR = os.path.join(BASE_DIR, 'backend', 'test_certificate', 'tmp')
 
 class LXDConfig:
-    LXD_HOST = os.environ.get('LXD_HOST', '192.168.1.230:8443')
+    LXD_HOST = '192.168.1.227:8443' if APP_ENV == 'test' else os.environ.get('LXD_HOST', '192.168.1.230:8443')
     LXD_CERT = (
         os.environ.get('LXD_CERT_PATH', os.path.join(CERT_DIR, 'lxd.crt')),
         os.environ.get('LXD_KEY_PATH', os.path.join(CERT_DIR, 'lxd.key')),

--- a/frontend/src/components/Common/Alert.tsx
+++ b/frontend/src/components/Common/Alert.tsx
@@ -3,7 +3,8 @@ import {
   InformationCircleIcon, 
   ExclamationCircleIcon, 
   CheckCircleIcon,
-  ExclamationTriangleIcon
+  ExclamationTriangleIcon,
+  XMarkIcon
 } from '@heroicons/react/24/outline'
 
 type AlertType = 'success' | 'error' | 'info' | 'warning'
@@ -12,9 +13,10 @@ interface AlertProps {
   type: AlertType
   message: string | React.ReactNode
   className?: string
+  onClose?: () => void
 }
 
-const Alert: React.FC<AlertProps> = ({ type, message, className = '' }) => {
+const Alert: React.FC<AlertProps> = ({ type, message, className = '', onClose }) => {
   const getAlertStyles = (): string => {
     switch (type) {
       case 'success':
@@ -43,10 +45,27 @@ const Alert: React.FC<AlertProps> = ({ type, message, className = '' }) => {
     }
   }
 
+  const handleClick = (e: React.MouseEvent) => {
+    if (onClose) {
+      onClose()
+    }
+  }
+
   return (
-    <div className={`p-3 border-l-4 rounded flex items-center ${getAlertStyles()} ${className}`} data-testid={`alert-${type}`}>
-      {getIcon()}
-      <p>{message}</p>
+    <div className={`p-3 border-l-4 rounded flex items-center justify-between ${getAlertStyles()} ${className}`} data-testid={`alert-${type}`}>
+      <div className="flex items-center flex-1">
+        {getIcon()}
+        <p className="flex-1">{message}</p>
+      </div>
+      {onClose && (
+        <button 
+          onClick={handleClick}
+          className="ml-2 hover:opacity-75 focus:outline-none"
+          aria-label="Close"
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/Instance/Create/ChooseOsImageSection.tsx
+++ b/frontend/src/components/Instance/Create/ChooseOsImageSection.tsx
@@ -85,6 +85,7 @@ const ChooseOsImageSection: React.FC<ChooseOsImageSectionProps> = React.memo(({
                         isSelected={imageName === selectedImageName}
                         onClick={() => onImageNameSelect(imageName)}
                         className="font-medium"
+                        data-testid={`os-image-${imageName.toLowerCase()}`}
                     />
                 ))}
             </div>
@@ -105,6 +106,7 @@ const ChooseOsImageSection: React.FC<ChooseOsImageSectionProps> = React.memo(({
                             position="bottom-left"
                             buttonType="default"
                             hasBorder={false}
+                            data-testid={`os-version-dropdown`}
                         />
                         
                         {selectedOsType && (

--- a/frontend/src/components/Instance/Create/ChooseSubscriptionPlanSection.tsx
+++ b/frontend/src/components/Instance/Create/ChooseSubscriptionPlanSection.tsx
@@ -46,6 +46,7 @@ const ChooseSubscriptionPlanSection: React.FC<ChooseSubscriptionPlanSectionProps
                         isSelected={selectedInstanceType?.instance_plan_id === packageOption.instance_plan_id}
                         onClick={() => onSelect(packageOption)}
                         className="font-medium"
+                        data-testid={`instance-plan-${packageOption.instance_package_name}`}
                     />
                 ))}
             </div>

--- a/frontend/src/components/Instance/Create/SetAuthSection.tsx
+++ b/frontend/src/components/Instance/Create/SetAuthSection.tsx
@@ -46,6 +46,7 @@ const SetAuthSection: React.FC<SetAuthSectionProps> = React.memo(({
                     placeholder="Enter secure password..."
                     endIcon={showPassword ? <EyeSlashIcon className="w-5 h-5" /> : <EyeIcon className="w-5 h-5" />}
                     onEndIconClick={togglePasswordVisibility}
+                    data-testid={`root-password-input`}
                 />
             </div>
 

--- a/frontend/src/components/Instance/Create/SetHostnameSection.tsx
+++ b/frontend/src/components/Instance/Create/SetHostnameSection.tsx
@@ -35,6 +35,7 @@ const SetHostnameSection: React.FC<SetHostnameSectionProps> = React.memo(({
                     placeholder="Enter hostname (e.g. web-server)"
                     sanitizeValue={sanitizeHostname}
                     helperText="Hostname can only contain lowercase letters, numbers, and hyphens. Special characters and spaces will be automatically removed."
+                    data-testid={`hostname-input`}
                 />
             </div>
         </Section>

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -1,49 +1,49 @@
-import React, { createContext, useContext, useState, ReactNode, useCallback, useEffect } from 'react';
-import Alert from '../components/Common/Alert';
+import React, { createContext, useContext, useState, ReactNode, useCallback, useEffect } from 'react'
+import Alert from '../components/Common/Alert'
 
-type AlertType = 'success' | 'error' | 'info' | 'warning';
+type AlertType = 'success' | 'error' | 'info' | 'warning'
 
 interface Notification {
-  id: string;
-  type: AlertType;
-  message: string;
-  autoDismiss?: boolean;
-  duration?: number;
-  timestamp: number;
+  id: string
+  type: AlertType
+  message: string
+  autoDismiss?: boolean
+  duration?: number
+  timestamp: number
 }
 
 interface NotificationContextProps {
-  notifications: Notification[];
-  addNotification: (type: AlertType, message: string, autoDismiss?: boolean, duration?: number) => void;
-  removeNotification: (id: string) => void;
-  clearNotifications: () => void;
+  notifications: Notification[]
+  addNotification: (type: AlertType, message: string, autoDismiss?: boolean, duration?: number) => void
+  removeNotification: (id: string) => void
+  clearNotifications: () => void
 }
 
-const NotificationContext = createContext<NotificationContextProps | undefined>(undefined);
+const NotificationContext = createContext<NotificationContextProps | undefined>(undefined)
 
 // Maximum number of notifications to show at one time
-const MAX_NOTIFICATIONS = 5;
+const MAX_NOTIFICATIONS = 5
 
 export const useNotification = () => {
-  const context = useContext(NotificationContext);
+  const context = useContext(NotificationContext)
   if (!context) {
-    throw new Error('useNotification must be used within a NotificationProvider');
+    throw new Error('useNotification must be used within a NotificationProvider')
   }
-  return context;
-};
+  return context
+}
 
 interface NotificationProviderProps {
-  children: ReactNode;
+  children: ReactNode
 }
 
 export const NotificationProvider: React.FC<NotificationProviderProps> = ({ children }) => {
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [lastTimestamp, setLastTimestamp] = useState(0);
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [lastTimestamp, setLastTimestamp] = useState(0)
 
   // Use useCallback to ensure stable identity for removeNotification function
   const removeNotification = useCallback((id: string) => {
-    setNotifications(prev => prev.filter(notification => notification.id !== id));
-  }, []);
+    setNotifications(prev => prev.filter(notification => notification.id !== id))
+  }, [])
 
   const addNotification = useCallback(
     (type: AlertType, message: string, autoDismiss = true, duration = 5000) => {
@@ -53,58 +53,59 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
           notification.message === message && 
           notification.type === type &&
           Date.now() - notification.timestamp < 2000 // Consider as duplicate if added within 2 seconds
-      );
+      )
       
-      if (isDuplicate) return;
+      if (isDuplicate) return
 
       // Ensure unique timestamps even when called in rapid succession
-      const now = Date.now();
-      const timestamp = now > lastTimestamp ? now : lastTimestamp + 1;
-      setLastTimestamp(timestamp);
+      const now = Date.now()
+      const timestamp = now > lastTimestamp ? now : lastTimestamp + 1
+      setLastTimestamp(timestamp)
       
-      const id = `${timestamp}-${Math.random().toString(36).substr(2, 9)}`;
-      const newNotification = { id, type, message, autoDismiss, duration, timestamp };
+      const id = `${timestamp}-${Math.random().toString(36).substr(2, 9)}`
+      const newNotification = { id, type, message, autoDismiss, duration, timestamp }
       
       setNotifications(prev => {
         // Add the new notification
-        const updatedNotifications = [...prev, newNotification];
+        const updatedNotifications = [...prev, newNotification]
         
-        // If we exceed the maximum number of notifications, keep only the most recent ones
+        // If we exceed the maximum number of notifications, remove the oldest one
         if (updatedNotifications.length > MAX_NOTIFICATIONS) {
+          // Sort by timestamp (oldest first) and remove the first one
           return updatedNotifications
-            .sort((a, b) => b.timestamp - a.timestamp)
-            .slice(0, MAX_NOTIFICATIONS);
+            .sort((a, b) => a.timestamp - b.timestamp)
+            .slice(1)
         }
         
-        return updatedNotifications;
-      });
+        return updatedNotifications
+      })
     },
     [notifications, lastTimestamp]
-  );
+  )
 
   // Use useEffect for auto-dismissing notifications to prevent memory leaks
   useEffect(() => {
     // Create a map to track timeout IDs
-    const timeoutIds: { [id: string]: number } = {};
+    const timeoutIds: { [id: string]: number } = {}
     
     // Set up timeouts for auto-dismissing notifications
     notifications.forEach(notification => {
       if (notification.autoDismiss && !timeoutIds[notification.id]) {
         timeoutIds[notification.id] = window.setTimeout(() => {
-          removeNotification(notification.id);
-        }, notification.duration || 5000);
+          removeNotification(notification.id)
+        }, notification.duration || 5000)
       }
-    });
+    })
     
     // Cleanup function to clear timeouts when component unmounts or notifications change
     return () => {
-      Object.values(timeoutIds).forEach(id => window.clearTimeout(id));
-    };
-  }, [notifications, removeNotification]);
+      Object.values(timeoutIds).forEach(id => window.clearTimeout(id))
+    }
+  }, [notifications, removeNotification])
 
   const clearNotifications = useCallback(() => {
-    setNotifications([]);
-  }, []);
+    setNotifications([])
+  }, [])
 
   return (
     <NotificationContext.Provider value={{ 
@@ -116,31 +117,32 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
       {children}
       <NotificationContainer />
     </NotificationContext.Provider>
-  );
-};
+  )
+}
 
 // Container that displays notifications in the UI
 const NotificationContainer: React.FC = () => {
-  const { notifications, removeNotification } = useNotification();
+  const { notifications, removeNotification } = useNotification()
 
-  if (notifications.length === 0) return null;
+  if (notifications.length === 0) return null
 
-  // Sort notifications to show most recent first
-  const sortedNotifications = [...notifications].sort((a, b) => b.timestamp - a.timestamp);
+  // Sort notifications by timestamp, oldest first
+  const sortedNotifications = [...notifications].sort((a, b) => a.timestamp - b.timestamp)
 
   return (
     <div className="fixed top-5 right-5 z-50 space-y-2 w-80">
       {sortedNotifications.map(notification => (
-        <div key={notification.id} className="relative" onClick={() => removeNotification(notification.id)}>
+        <div key={notification.id} className="relative">
           <Alert 
             type={notification.type} 
             message={notification.message} 
-            className="cursor-pointer shadow-lg hover:shadow-xl transition-shadow"
+            className="shadow-lg hover:shadow-xl transition-shadow"
+            onClose={() => removeNotification(notification.id)}
           />
         </div>
       ))}
     </div>
-  );
-};
+  )
+}
 
-export default NotificationProvider; 
+export default NotificationProvider 

--- a/frontend/src/contexts/baseContext.tsx
+++ b/frontend/src/contexts/baseContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useReducer, ReactNode, Reducer, useEffect } from 'react'
 import useToast from '../hooks/useToast'
+import React from 'react'
 
 // Generic type for context state
 export interface BaseContextState {
@@ -24,11 +25,26 @@ const CommonProvider = <T extends BaseContextState>({
   Context: React.Context<T | undefined> 
 }) => {
   const toast = useToast()
+  const prevErrorRef = React.useRef<string | null>(null)
   
   // Handle error state at the context level
   useEffect(() => {
-    if (contextValue.error && contextValue.error !== '') {
+    // Only process if there's an actual error
+    if (!contextValue.error || contextValue.error === '') {
+      // Reset prevError when error is cleared
+      if (prevErrorRef.current !== null) {
+        prevErrorRef.current = null
+      }
+      return
+    }
+    
+    // If this is a new error or an error that changed
+    if (contextValue.error !== prevErrorRef.current) {
+      // Show the error toast
       toast.error(contextValue.error)
+      
+      // Update the previous error reference
+      prevErrorRef.current = contextValue.error
     }
   }, [contextValue.error, toast])
   

--- a/frontend/src/hooks/Instance/useInstanceCreate.ts
+++ b/frontend/src/hooks/Instance/useInstanceCreate.ts
@@ -11,6 +11,7 @@ import { useInstance } from "../../contexts/instanceContext"
 import { INSTANCE_ACTIONS } from "../../contexts/instanceContext"
 import { useInstanceList } from "./useInstanceList"
 import useToast from "../useToast"
+import { useNavigate, useParams } from "react-router-dom"
 
 export const useInstanceCreate = () => {
     const {
@@ -108,6 +109,8 @@ export const useInstanceCreate = () => {
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
     const [selectedImageName, setSelectedImageName] = useState<string>("")
     const [selectedVersion, setSelectedVersion] = useState<string>("")
+    const { userName } = useParams<{ userName: string }>()
+    const navigate = useNavigate()
     const toast = useToast()
 
     // Fetch instance details on component mount
@@ -226,6 +229,14 @@ export const useInstanceCreate = () => {
         return result
     }, [formSubmit, dispatch, refreshInstances])
 
+    const handleSubmitCreateInstance = useCallback(async () => {
+        const result = await createInstance()
+
+        if (result && result.success) {
+            toast.success('Instance created successfully')
+            navigate(`/user/${userName}/instance`)
+        }
+    }, [createInstance, navigate, userName])
 
     return {
         instanceDetails,
@@ -247,6 +258,7 @@ export const useInstanceCreate = () => {
         createInstance,
         handleImageNameSelect,
         handleVersionSelect,
-        fetchInstanceDetails
+        fetchInstanceDetails,
+        handleSubmitCreateInstance
     }
 }

--- a/frontend/src/pages/Instance/InstanceCreatePage.tsx
+++ b/frontend/src/pages/Instance/InstanceCreatePage.tsx
@@ -25,7 +25,7 @@ const InstanceCreatePage: React.FC = () => {
         handleInstancePlanSelect,
         handleRootPasswordChange,
         handleInstanceNameChange,
-        createInstance,
+        handleSubmitCreateInstance,
         selectedImageName,
         selectedVersion,
         uniqueImageNames,
@@ -33,16 +33,6 @@ const InstanceCreatePage: React.FC = () => {
         handleImageNameSelect,
         handleVersionSelect
     } = useInstanceCreate()
-
-    const handleSubmit = async () => {
-        const result = await createInstance()
-        
-        if (result && result.success) {
-            alert("Instance created successfully!")
-            // Redirect to instances list page after successful creation
-            navigate(`/user/${userName}/instance`)
-        }
-    }
 
     // Loading state UI
     if (isLoading) {
@@ -77,7 +67,7 @@ const InstanceCreatePage: React.FC = () => {
         <div className="py-4">
             <Button 
                 label={isSubmitting ? "Creating Instance..." : "Launch Instance"}
-                onClick={handleSubmit}
+                onClick={handleSubmitCreateInstance}
                 variant="purple"
                 className={`py-3 ${!isFormValid || isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
                 icon={isSubmitting ? 
@@ -85,6 +75,7 @@ const InstanceCreatePage: React.FC = () => {
                     <RocketLaunchIcon className="w-5 h-5" />
                 }
                 disabled={!isFormValid || isSubmitting}
+                data-testid="instance-create-page-submit"
             />
         </div>
     )

--- a/frontend/src/pages/Instance/InstanceListPage.tsx
+++ b/frontend/src/pages/Instance/InstanceListPage.tsx
@@ -111,6 +111,7 @@ const InstanceListPage: React.FC = () => {
                 label="Create Instance"
                 variant="secondary"
                 icon={<PlusIcon className="w-4 h-4" />}
+                data-testid="top-navbar-create-instance"
             />
             <NotificationBadge
                 count={notificationCount}

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,19 +2,13 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-ENV DOCKER=true
-
 # Install make, git and xvfb
 RUN apt-get update && apt-get install -y make git xvfb
 
 # Copy the test directory
 COPY . .
 
-# Install dependencies using make
-RUN make install
-
-# Install Playwright browsers
-RUN make install-browsers
+RUN DOCKER=true make setup
 
 # Run the tests using make
 CMD ["bash", "-c", "make test-e2e"] 

--- a/test/e2e/api/__init__.py
+++ b/test/e2e/api/__init__.py
@@ -1,0 +1,3 @@
+"""
+API package for interacting with the backend.
+""" 

--- a/test/e2e/api/client.py
+++ b/test/e2e/api/client.py
@@ -1,0 +1,127 @@
+"""
+API client for making requests to the backend.
+This module provides a clean interface for making API requests with consistent error handling.
+"""
+import json
+from typing import Dict, Any, Optional
+from playwright.sync_api import Page, APIResponse
+
+from ..data.models import UserData
+
+class ApiClient:
+    """
+    A client for making API requests with consistent error handling.
+    This class centralizes all API interactions for better maintainability.
+    """
+    def __init__(self, page: Page, base_url: str):
+        """
+        Initialize the API client with a page and base URL.
+        
+        Args:
+            page: The Page object to use for making requests
+            base_url: The base URL for all API requests
+        """
+        self.page = page
+        self.base_url = base_url
+        
+    def make_request(
+        self, 
+        endpoint: str, 
+        data: Optional[Dict[str, Any]] = None,
+        method: str = "post", 
+        action_name: str = "API request"
+    ) -> Optional[APIResponse]:
+        """
+        Make an API request with error handling.
+        
+        Args:
+            endpoint: The API endpoint (will be appended to base_url)
+            data: The data to send in the request body
+            method: The HTTP method to use (get, post, put, delete, etc.)
+            action_name: A name for the action (used in logging)
+            
+        Returns:
+            The API response if successful, None if the request failed in a non-critical way
+        """
+        if self.page is None:
+            return None
+            
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+            
+        try:
+            # Get the appropriate method from the APIRequestContext
+            request_method = getattr(self.page.context.request, method.lower())
+            
+            # Prepare arguments for the request
+            kwargs = {"headers": {"Content-Type": "application/json"}}
+            
+            # Only include data for methods that support a body
+            if data is not None and method.lower() not in ["get", "head"]:
+                kwargs["data"] = json.dumps(data)
+                
+            # For GET requests, convert data to params if provided
+            if method.lower() == "get" and data is not None:
+                kwargs["params"] = data
+                
+            # Make the request
+            response = request_method(url, **kwargs)
+            
+            if response.status >= 400:
+                print(f"{action_name} warning - Status: {response.status}")
+                try:
+                    error_details = response.json()
+                    print(f"{action_name} details: {error_details}")
+                except Exception:
+                    print(f"Could not parse error response: {response.text()[:100]}...")
+                
+                if response.status >= 500:
+                    print(f"Server error detected, skipping {action_name}")
+                    return None
+                elif response.status != 409:  # 409 = User already exists (acceptable for registration)
+                    if "login" in action_name.lower() and response.status == 401:
+                        raise Exception(f"Authentication failed: Invalid credentials")
+                    else:
+                        raise Exception(f"{action_name} failed with status {response.status}")
+            
+            return response
+        except json.JSONDecodeError as e:
+            print(f"{action_name} response is not valid JSON: {str(e)}")
+            return None
+        except Exception as e:
+            print(f"{action_name} exception: {str(e)}")
+            if "502 Bad Gateway" in str(e):
+                print(f"502 Bad Gateway detected, skipping {action_name}")
+                return None
+            raise
+    
+    # User Management API Methods
+    def register_user(self, user: UserData) -> Optional[APIResponse]:
+        """Register a new user"""
+        data = {
+            "username": user.username,
+            "email": user.email,
+            "password": user.password
+        }
+        return self.make_request("user/register", data, action_name="Registration")
+    
+    def create_admin_user(self, user: UserData) -> Optional[APIResponse]:
+        """Create an admin user"""
+        data = {
+            "username": user.username,
+            "email": user.email,
+            "password": user.password
+        }
+        return self.make_request("user/admin/create", data, action_name="Admin creation")
+    
+    def login_user(self, user: UserData) -> Optional[APIResponse]:
+        """Login a user"""
+        data = {
+            "username": user.username,
+            "password": user.password
+        }
+        return self.make_request("user/login", data, action_name="Login")
+        
+    # Instance Management API Methods
+    def delete_instance(self, hostname: str) -> Optional[APIResponse]:
+        """Delete an instance by hostname"""
+        return self.make_request(f"instance/{hostname}/delete", method="post", action_name="Delete Instance") 

--- a/test/e2e/api/client.py
+++ b/test/e2e/api/client.py
@@ -6,7 +6,7 @@ import json
 from typing import Dict, Any, Optional
 from playwright.sync_api import Page, APIResponse
 
-from ..data.models import UserData
+from ..data.models import UserData, UserInstanceData
 
 class ApiClient:
     """
@@ -124,4 +124,33 @@ class ApiClient:
     # Instance Management API Methods
     def delete_instance(self, hostname: str) -> Optional[APIResponse]:
         """Delete an instance by hostname"""
-        return self.make_request(f"instance/{hostname}/delete", method="post", action_name="Delete Instance") 
+        return self.make_request(f"instance/{hostname}/delete", method="post", action_name="Delete Instance")
+    
+    def create_instance(self, instance_data: UserInstanceData) -> Optional[APIResponse]:
+        """
+        Create a new instance
+        
+        Args:
+            instance_data: Instance configuration data
+            
+        Returns:
+            API response if successful, None otherwise
+        """
+        data = {
+            "instance_name": instance_data.hostname,
+            "root_password": instance_data.root_password,
+            "os_type": {
+                "os_type_id": instance_data.os_type.os_type_id,
+                "os_image_name": instance_data.os_type.os_image_name,
+                "os_image_version": instance_data.os_type.os_image_version
+            },
+            "instance_plan": {
+                "instance_plan_id": instance_data.instance_plan.instance_plan_id,
+                "instance_package_name": instance_data.instance_plan.instance_package_name,
+                "vcpu_amount": instance_data.instance_plan.vcpu_amount,
+                "ram_amount": instance_data.instance_plan.ram_amount,
+                "storage_amount": instance_data.instance_plan.storage_amount,
+                "cost_hour": instance_data.instance_plan.cost_hour
+            }
+        }
+        return self.make_request("instance/create", data, action_name="Create Instance") 

--- a/test/e2e/data/models.py
+++ b/test/e2e/data/models.py
@@ -3,7 +3,9 @@ Data models for E2E testing fixtures.
 These models ensure type safety and data consistency across tests.
 """
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import List, Optional
+import uuid
 
 @dataclass
 class RegisterData:
@@ -35,27 +37,38 @@ class UserData:
 
 
 @dataclass
-class InstanceData:
+class InstancePlanData:
+    """
+    Data model for instance plan fixture data used in instance management tests.
+    """
+    instance_plan_id: int
+    instance_package_name: str
+    vcpu_amount: int
+    ram_amount: int
+    storage_amount: int
+    cost_hour: float
+
+@dataclass
+class OsTypeData:
+    """
+    Data model for os type fixture data used in instance management tests.
+    """
+    os_type_id: int
+    os_image_name: str
+    os_image_version: str
+
+@dataclass
+class UserInstanceData:
     """
     Data model for instance fixture data used in instance management tests.
     """
-    name: str
-    plan: str
-    description: Optional[str] = None
-    storage_gb: int = 10
-    cpu_cores: int = 1
-    ram_gb: int = 2
-    tags: List[str] = field(default_factory=list)
-
-
-@dataclass
-class BillingData:
-    """
-    Data model for billing fixture data used in billing tests.
-    """
-    card_number: str
-    expiry_month: int
-    expiry_year: int
-    cvv: str
-    name_on_card: str
-    billing_address: str 
+    instance_plan: InstancePlanData
+    os_type: OsTypeData
+    hostname: str
+    lxd_node_name: str
+    status: str
+    root_password: str
+    last_updated_at: datetime
+    instance_id: Optional[uuid.UUID] = None
+    user_id: Optional[uuid.UUID] = None
+    created_at: Optional[datetime] = None

--- a/test/e2e/pages/base_class.py
+++ b/test/e2e/pages/base_class.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, TypeVar, Dict, List, Union
+from typing import Optional, Any, TypeVar, Dict, List, Union, Callable
 from playwright.sync_api import Page, Locator, expect
 from .common.toast import Toast
 
@@ -10,18 +10,25 @@ class BasePage:
     """
     path: str = ""
     
-    def __init__(self, page: Page, path: Optional[str] = None):
+    def __init__(self, page: Page, path: Optional[str] = None, username: Optional[str] = None):
         """
-        Initialize the page object with a Playwright page instance and optional path override.
+        Initialize the page object with a Playwright page instance and optional parameters.
         
         Args:
             page: Playwright Page object
             path: Optional path to navigate to (overrides the class path)
+            username: Optional username to format into the path
         """
         self.page = page
         self.toast = Toast(self.page)
+        self.username = username
+        
         if path is not None:
             self.path = path
+            
+        # Format username into path if provided and path contains {username} placeholder
+        if username is not None and "{username}" in self.path:
+            self.path = self.path.format(username=username)
     
     def is_current(self) -> bool:
         """
@@ -49,5 +56,90 @@ class BasePage:
     def wait_for_page_load(self) -> None:
         """
         Wait for the page to be fully loaded.
+        DEPRECATED: Use more specific waiting methods instead.
         """
-        self.page.wait_for_load_state("networkidle")
+        # This method is kept for backward compatibility
+        # Use wait_for_locator or wait_for_event instead
+        self.page.wait_for_load_state("load")
+        
+    def wait_for_locator(self, locator: Locator, state: str = "visible", timeout: int = 30000) -> Locator:
+        """
+        Wait for a locator to be in the specified state.
+        
+        Args:
+            locator: The locator to wait for
+            state: The state to wait for (visible, hidden, attached, detached)
+            timeout: Maximum time to wait in milliseconds
+            
+        Returns:
+            The locator for chaining
+        """
+        locator.wait_for(state=state, timeout=timeout)
+        return locator
+    
+    def wait_for_event(self, event: str, predicate: Optional[Callable] = None, timeout: int = 30000) -> Any:
+        """
+        Wait for a specific event to occur.
+        
+        Args:
+            event: Event name to wait for
+            predicate: Optional function to filter events
+            timeout: Maximum time to wait in milliseconds
+            
+        Returns:
+            The event data
+        """
+        with self.page.expect_event(event, predicate=predicate, timeout=timeout) as event_info:
+            pass  # The expectation is already set up, no action needed here
+        return event_info.value
+    
+    def wait_for_response(self, url_pattern: str, timeout: int = 30000) -> Any:
+        """
+        Wait for a network response matching the specified URL pattern.
+        
+        Args:
+            url_pattern: URL pattern to match (supports glob patterns)
+            timeout: Maximum time to wait in milliseconds
+            
+        Returns:
+            The response object
+        """
+        with self.page.expect_response(url_pattern, timeout=timeout) as response_info:
+            pass  # The expectation is already set up, no action needed here
+        return response_info.value
+    
+    def wait_for_navigation(self, url_pattern: Optional[str] = None, timeout: int = 30000) -> None:
+        """
+        Wait for navigation to complete, optionally to a specific URL.
+        
+        Args:
+            url_pattern: Optional URL pattern to wait for
+            timeout: Maximum time to wait in milliseconds
+        """
+        if url_pattern:
+            self.page.wait_for_url(url_pattern, timeout=timeout)
+        else:
+            self.page.wait_for_load_state("load", timeout=timeout)
+            
+    def wait_for_toast(self, toast_type: str = "success", timeout: int = 10000) -> Locator:
+        """
+        Wait for a toast notification to appear.
+        
+        Args:
+            toast_type: Type of toast to wait for ("success", "error", "info", or "warning")
+            timeout: Maximum time to wait in milliseconds
+            
+        Returns:
+            The toast locator
+        """
+        toast_map = {
+            "success": self.toast.success_toast,
+            "error": self.toast.error_toast,
+            "info": self.toast.info_toast,
+            "warning": self.toast.warning_toast
+        }
+        
+        if toast_type not in toast_map:
+            raise ValueError(f"Invalid toast type: {toast_type}. Valid options are: {', '.join(toast_map.keys())}")
+            
+        return self.wait_for_locator(toast_map[toast_type], state="visible", timeout=timeout)

--- a/test/e2e/pages/common/toast.py
+++ b/test/e2e/pages/common/toast.py
@@ -4,10 +4,10 @@ class Toast:
     def __init__(self, page: Page):
         self.page = page
 
-        self.success_toast = self.page.get_by_test_id("alert-success")
-        self.error_toast = self.page.get_by_test_id("alert-error")
-        self.info_toast = self.page.get_by_test_id("alert-info")
-        self.warning_toast = self.page.get_by_test_id("alert-warning")
+        self.success_toast = self.page.get_by_test_id("alert-success").first
+        self.error_toast = self.page.get_by_test_id("alert-error").first
+        self.info_toast = self.page.get_by_test_id("alert-info").first
+        self.warning_toast = self.page.get_by_test_id("alert-warning").first
         
     def should_show_success_toast(self):
         expect(self.success_toast).to_be_visible()

--- a/test/e2e/pages/instance/__init__.py
+++ b/test/e2e/pages/instance/__init__.py
@@ -4,9 +4,9 @@ This package contains page objects for instance listing, creation, and managemen
 """
 
 from .instance_list_page import InstanceListPage
-# from .instance_create_page import InstanceCreatePage
+from .instance_create_page import InstanceCreatePage
 
 __all__ = [
     'InstanceListPage',
-    # 'InstanceCreatePage'
+    'InstanceCreatePage'
 ]

--- a/test/e2e/pages/instance/instance_create_page.py
+++ b/test/e2e/pages/instance/instance_create_page.py
@@ -7,7 +7,7 @@ class InstanceCreatePage(BasePage):
     path: str = "/user/{username}/instance/create"
     
     def __init__(self, page: Page, username: str):
-        super().__init__(page, self.path.format(username=username))
+        super().__init__(page, username=username)
 
         self.side_nav = SideNavBar(page)
         self.os_image_section = {

--- a/test/e2e/pages/instance/instance_create_page.py
+++ b/test/e2e/pages/instance/instance_create_page.py
@@ -1,0 +1,60 @@
+from playwright.sync_api import Page, expect
+
+from ..base_class import BasePage
+from ..common.side_nav_bar import SideNavBar
+
+class InstanceCreatePage(BasePage):
+    path: str = "/user/{username}/instance/create"
+    
+    def __init__(self, page: Page, username: str):
+        super().__init__(page, self.path.format(username=username))
+
+        self.side_nav = SideNavBar(page)
+        self.os_image_section = {
+            "os_option_button": {
+                "ubuntu": page.get_by_test_id("os-image-ubuntu-option-button"),
+                "debian": page.get_by_test_id("os-image-debian-option-button"),
+                "fedora": page.get_by_test_id("os-image-fedora-option-button"),
+            },
+            "os_version_dropdown": page.get_by_test_id("os-version-dropdown-dropdown-button"),
+            "os_version_dropdown_item": page.get_by_test_id("os-version-dropdown-dropdown-item-button-0"),
+        }
+        self.instance_plan_section = {
+            "compute_option_button": page.get_by_test_id("instance-plan-compute-2-option-button"),
+            "memory_option_button": page.get_by_test_id("instance-plan-memory-2-option-button"),
+            "micro_option_button": page.get_by_test_id("instance-plan-micro-1-option-button"),
+            "nano_option_button": page.get_by_test_id("instance-plan-nano-1-option-button"),
+            "performance_option_button": page.get_by_test_id("instance-plan-performance-16-option-button"),
+            "standard_option_button": page.get_by_test_id("instance-plan-standard-2-option-button"),
+            "storage_option_button": page.get_by_test_id("instance-plan-storage-2-option-button"),
+        }
+        self.set_auth_section = {
+            "password_input": page.get_by_test_id("root-password-input-input-field")
+        }
+        self.set_hostname_section = {
+            "hostname_input": page.get_by_test_id("hostname-input-input-field")
+        }
+        self.create_instance_button = page.get_by_test_id("instance-create-page-submit-button")
+
+    def choose_os_image(self, os_image: str):
+        self.os_image_section["os_option_button"][os_image].click()
+        self.os_image_section["os_version_dropdown"].click()
+        self.os_image_section["os_version_dropdown_item"].click()
+        
+    def choose_instance_plan(self, instance_plan: str):
+        self.instance_plan_section[f"{instance_plan}_option_button"].click()
+        
+    def set_root_password(self, password: str):
+        self.set_auth_section["password_input"].fill(password)
+        
+    def set_hostname(self, hostname: str):
+        self.set_hostname_section["hostname_input"].fill(hostname)
+        
+    def click_create_instance_button(self):
+        self.create_instance_button.click()
+        
+    def should_disable_create_instance_button(self):
+        expect(self.create_instance_button).to_be_disabled()
+    
+    def should_navigate_to_instance_dashboard(self):
+        expect(self.page).to_have_url(f"/user/{self.username}/instance")

--- a/test/e2e/pages/instance/instance_list_page.py
+++ b/test/e2e/pages/instance/instance_list_page.py
@@ -7,7 +7,7 @@ class InstanceListPage(BasePage):
     path: str = "/user/{username}/instance"
     
     def __init__(self, page: Page, username: str):
-        super().__init__(page, self.path.format(username=username))
+        super().__init__(page, username=username)
         
         self.side_nav = SideNavBar(page)
         self.create_instance_button = page.get_by_test_id("top-navbar-create-instance-button")

--- a/test/e2e/pages/instance/instance_list_page.py
+++ b/test/e2e/pages/instance/instance_list_page.py
@@ -10,7 +10,10 @@ class InstanceListPage(BasePage):
         super().__init__(page, self.path.format(username=username))
         
         self.side_nav = SideNavBar(page)
+        self.create_instance_button = page.get_by_test_id("top-navbar-create-instance-button")
+    
+    def click_create_instance_button(self):
+        self.create_instance_button.click()
         
-        
-        
-        
+    def should_navigate_to_instance_create_page(self):
+        expect(self.page).to_have_url(f"/user/{self.username}/instance/create")

--- a/test/e2e/registry/__init__.py
+++ b/test/e2e/registry/__init__.py
@@ -1,0 +1,3 @@
+"""
+Registry package for managing test actions and lifecycle.
+""" 

--- a/test/e2e/registry/actions.py
+++ b/test/e2e/registry/actions.py
@@ -24,7 +24,7 @@ TestData = List[Any]
 # Define type variables for decorator
 F = TypeVar('F', bound=Callable[..., Any])
 
-class TestActionRegistry:
+class ActionRegistry:
     """
     Registry to store before/after actions for tests.
     This allows for a more flexible way to configure test setup/teardown.

--- a/test/e2e/registry/actions.py
+++ b/test/e2e/registry/actions.py
@@ -1,0 +1,106 @@
+"""
+Registry for managing test actions and lifecycle.
+"""
+import pytest
+import functools
+import inspect
+from typing import Dict, Any, List, Protocol, Callable, TypeVar, cast, Set, Tuple, Optional
+from playwright.sync_api import Page
+
+from ..api.client import ApiClient
+
+# Define Protocol for action functions
+class BeforeActionFn(Protocol):
+    def __call__(self, page: Page, backend_url: str, request: pytest.FixtureRequest, api_client: ApiClient, **kwargs: Any) -> Any:
+        ...
+
+class AfterActionFn(Protocol):
+    def __call__(self, page: Page, backend_url: str, request: pytest.FixtureRequest, api_client: ApiClient, **kwargs: Any) -> None:
+        ...
+
+# Alias for test data returned from actions
+TestData = List[Any]
+
+# Define type variables for decorator
+F = TypeVar('F', bound=Callable[..., Any])
+
+class TestActionRegistry:
+    """
+    Registry to store before/after actions for tests.
+    This allows for a more flexible way to configure test setup/teardown.
+    """
+    def __init__(self) -> None:
+        self.before_actions: List[BeforeActionFn] = []
+        self.after_actions: List[AfterActionFn] = []
+        
+    def register_before(self, action_fn: BeforeActionFn) -> BeforeActionFn:
+        """Register a function to run before each test"""
+        self.before_actions.append(action_fn)
+        return action_fn  # Return for use as decorator
+        
+    def register_after(self, action_fn: AfterActionFn) -> AfterActionFn:
+        """Register a function to run after each test"""
+        self.after_actions.append(action_fn)
+        return action_fn  # Return for use as decorator
+    
+    def action(self, is_before: bool = True) -> Callable[[F], F]:
+        """
+        Flexible decorator for registering actions with specific parameters.
+        Will automatically extract only the parameters that the decorated function needs.
+        
+        Usage:
+            @action_registry.action()  # Default is before action
+            def my_action(page: Page, api_client: ApiClient):
+                # Only gets page and api_client, other parameters are ignored
+                
+            @action_registry.action(is_before=False)  # Register as after action
+            def my_cleanup(backend_url: str):
+                # Only gets backend_url
+        """
+        def decorator(fn: F) -> F:
+            # Get parameter names from the function signature
+            sig = inspect.signature(fn)
+            param_names = set(sig.parameters.keys())
+            
+            @functools.wraps(fn)
+            def wrapper(**kwargs: Any) -> Any:
+                # Extract only the parameters needed by the function
+                filtered_kwargs = {k: v for k, v in kwargs.items() if k in param_names}
+                return fn(**filtered_kwargs)
+            
+            # Add to the appropriate list
+            if is_before:
+                self.before_actions.append(cast(BeforeActionFn, wrapper))
+            else:
+                self.after_actions.append(cast(AfterActionFn, wrapper))
+                
+            return cast(F, fn)  # Return original function for use as decorator
+        
+        return decorator
+    
+    def before(self) -> Callable[[F], F]:
+        """Shorthand for action(is_before=True)"""
+        return self.action(is_before=True)
+    
+    def after(self) -> Callable[[F], F]:
+        """Shorthand for action(is_before=False)"""
+        return self.action(is_before=False)
+        
+    def run_before_actions(self, **kwargs: Any) -> TestData:
+        """Run all registered before actions"""
+        results: TestData = []
+        for action in self.before_actions:
+            try:
+                result = action(**kwargs)
+                results.append(result)
+            except Exception as e:
+                print(f"Error in before action {action.__name__}: {str(e)}")
+        return results
+        
+    def run_after_actions(self, **kwargs: Any) -> None:
+        """Run all registered after actions"""
+        for action in reversed(self.after_actions):
+            try:
+                action(**kwargs)
+            except Exception as e:
+                print(f"Error in after action {action.__name__}: {str(e)}") 

--- a/test/e2e/scenarios/test_authorization.py
+++ b/test/e2e/scenarios/test_authorization.py
@@ -6,7 +6,7 @@ from ..pages.auth import RegisterPage, LoginPage
 from ..pages.instance import InstanceListPage
 from ..data.models import RegisterData, UserData, LoginData
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def invalid_user_data() -> UserData:
     return UserData(
         email="email",
@@ -15,7 +15,7 @@ def invalid_user_data() -> UserData:
         role="user"
     )
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def test_user_auth() -> UserData:
     """
     Fixture that provides test user data for authenticated tests.
@@ -40,6 +40,7 @@ class TestAuthorization:
             password=test_user_auth.password
         ))
         register_page.click_register()
+        register_page.wait_for_toast("success")
         register_page.toast.should_show_success_toast()
         register_page.should_navigate_to_login_page()
         
@@ -50,6 +51,7 @@ class TestAuthorization:
             password=test_user_auth.password
         ))
         login_page.click_login()
+        login_page.wait_for_toast("success")
         login_page.toast.should_show_success_toast()
         login_page.should_navigate_to_user_dashboard(test_user_auth.username)
         
@@ -57,7 +59,7 @@ class TestAuthorization:
         instance_list_page = InstanceListPage(page, test_user_auth.username)
         instance_list_page.wait_for_page_load()
         instance_list_page.side_nav.click_user_menu_item("logout")
-        instance_list_page.toast.should_show_success_toast()
+        instance_list_page.wait_for_toast("success")
         register_page.should_navigate_to_login_page()
     
     @pytest.mark.skip_auth
@@ -84,6 +86,7 @@ class TestAuthorization:
             password=test_user_auth.password
         ))
         register_page.click_register()
+        register_page.wait_for_toast("error")
         register_page.toast.should_show_error_toast()
     
     @pytest.mark.skip_auth
@@ -95,5 +98,6 @@ class TestAuthorization:
             password=invalid_user_data.password
         ))
         login_page.click_login()
+        login_page.wait_for_toast("error")
         login_page.toast.should_show_error_toast()
         

--- a/test/e2e/scenarios/test_instance_create.py
+++ b/test/e2e/scenarios/test_instance_create.py
@@ -5,11 +5,11 @@ from playwright.sync_api import Page, expect, Browser
 
 from ..pages.auth import RegisterPage, LoginPage
 from ..pages.instance import InstanceListPage, InstanceCreatePage
-from ..data.models import InstancePlanData, OsTypeData, UserInstanceData
-from ..registry.actions import TestActionRegistry, TestData
+from ..data.models import InstancePlanData, OsTypeData, UserData, UserInstanceData
+from ..registry.actions import ActionRegistry, TestData
 from ..api.client import ApiClient
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def test_instance_plan() -> InstancePlanData:
     return InstancePlanData(
         instance_plan_id=1,
@@ -20,7 +20,7 @@ def test_instance_plan() -> InstancePlanData:
         cost_hour=0.005
     )
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def test_os_type() -> OsTypeData:
     return OsTypeData(
         os_type_id=11,
@@ -28,7 +28,7 @@ def test_os_type() -> OsTypeData:
         os_image_version="bookworm"
     )
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def test_user_instance(
     test_instance_plan: InstancePlanData,
     test_os_type: OsTypeData
@@ -36,8 +36,8 @@ def test_user_instance(
     return UserInstanceData(
         instance_plan=test_instance_plan,
         os_type=test_os_type,
-        hostname="test_hostname",
-        lxd_node_name="test_lxd_node_name",
+        hostname="test-hostname",
+        lxd_node_name="test-lxd-node-name",
         status="running",
         root_password="Password123!",
         created_at=datetime.now(),
@@ -46,28 +46,60 @@ def test_user_instance(
 
 # Standard actions for all tests in this module
 @pytest.fixture(scope="module", autouse=True)
-def setup_standard_actions(action_registry: TestActionRegistry, test_user_instance: UserInstanceData) -> None:
+def setup_standard_actions(action_registry: ActionRegistry, test_user_instance: UserInstanceData) -> None:
     """
     Register standard instance actions for all tests in this module.
     The autouse=True ensures this runs automatically.
     """
     @action_registry.after()
-    def cleanup_instance(page: Page, backend_url: str, api_client: ApiClient) -> None:
+    def cleanup_instance(api_client: ApiClient) -> None:
         """Cleanup the instance after each test"""
         api_client.delete_instance(test_user_instance.hostname)
 
 class TestInstanceCreate:
-    def test_create_instance(self, page: Page, test_lifecycle: TestData, test_user_instance: UserInstanceData) -> None:
-        instance_list_page = InstanceListPage(page)
+    def test_valid_data_create_instance(self, page: Page, test_user_instance: UserInstanceData, test_user: UserData) -> None:
+        instance_list_page = InstanceListPage(page, test_user.username)
         instance_list_page.navigate()
-        instance_list_page.click_create_instance()
+        instance_list_page.click_create_instance_button()
         instance_list_page.should_navigate_to_instance_create_page()
 
-        instance_create_page = InstanceCreatePage(page)
-        instance_create_page.choose_os_image(test_user_instance.os_type.os_image_name)
-        instance_create_page.choose_instance_plan(test_user_instance.instance_plan.instance_package_name)
+        # Create button is disabled until all fields are filled
+        instance_create_page = InstanceCreatePage(page, test_user.username)
+        instance_create_page.choose_os_image(test_user_instance.os_type.os_image_name.lower())
+        instance_create_page.should_disable_create_instance_button() # Check that create button is disabled
+        instance_create_page.choose_instance_plan(test_user_instance.instance_plan.instance_package_name.split("-")[0])
+        instance_create_page.should_disable_create_instance_button() # Check that create button is disabled
         instance_create_page.set_root_password(test_user_instance.root_password)
+        instance_create_page.should_disable_create_instance_button() # Check that create button is disabled
         instance_create_page.set_hostname(test_user_instance.hostname)
         instance_create_page.click_create_instance_button()
+
+        # During the creation, the create button is disabled
+        instance_create_page.should_disable_create_instance_button() # Check that create button is disabled
+        
+        # Wait for success toast to appear
+        instance_create_page.wait_for_toast("success")
         instance_create_page.toast.should_show_success_toast()
         instance_create_page.should_navigate_to_instance_dashboard()
+    
+    # Including the test_lifecycle fixture ensures registered actions will be executed only for this test
+    def test_create_with_existing_hostname(self, page: Page, test_lifecycle: TestData, test_user_instance: UserInstanceData, test_user: UserData) -> None:
+        instance_list_page = InstanceListPage(page, test_user.username)
+        instance_list_page.navigate()
+        instance_list_page.click_create_instance_button()
+        instance_list_page.should_navigate_to_instance_create_page()
+
+        # Create button is disabled until all fields are filled
+        instance_create_page = InstanceCreatePage(page, test_user.username)
+        instance_create_page.choose_os_image(test_user_instance.os_type.os_image_name.lower())
+        instance_create_page.should_disable_create_instance_button() # Check that create button is disabled
+        instance_create_page.choose_instance_plan(test_user_instance.instance_plan.instance_package_name.split("-")[0])
+        instance_create_page.should_disable_create_instance_button() # Check that create button is disabled
+        instance_create_page.set_root_password(test_user_instance.root_password)
+        instance_create_page.should_disable_create_instance_button() # Check that create button is disabled
+        instance_create_page.set_hostname(test_user_instance.hostname)
+        instance_create_page.click_create_instance_button()
+
+        # Wait for the error toast
+        instance_create_page.wait_for_toast("error")
+        instance_create_page.toast.should_show_error_toast()

--- a/test/e2e/scenarios/test_instance_create.py
+++ b/test/e2e/scenarios/test_instance_create.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+import pytest
+from typing import Dict, Any
+from playwright.sync_api import Page, expect, Browser
+
+from ..pages.auth import RegisterPage, LoginPage
+from ..pages.instance import InstanceListPage, InstanceCreatePage
+from ..data.models import InstancePlanData, OsTypeData, UserInstanceData
+from ..registry.actions import TestActionRegistry, TestData
+from ..api.client import ApiClient
+
+@pytest.fixture
+def test_instance_plan() -> InstancePlanData:
+    return InstancePlanData(
+        instance_plan_id=1,
+        instance_package_name="nano-1",
+        vcpu_amount=1,
+        ram_amount=1,
+        storage_amount=10,
+        cost_hour=0.005
+    )
+
+@pytest.fixture
+def test_os_type() -> OsTypeData:
+    return OsTypeData(
+        os_type_id=11,
+        os_image_name="Debian",
+        os_image_version="bookworm"
+    )
+
+@pytest.fixture
+def test_user_instance(
+    test_instance_plan: InstancePlanData,
+    test_os_type: OsTypeData
+) -> UserInstanceData:
+    return UserInstanceData(
+        instance_plan=test_instance_plan,
+        os_type=test_os_type,
+        hostname="test_hostname",
+        lxd_node_name="test_lxd_node_name",
+        status="running",
+        root_password="Password123!",
+        created_at=datetime.now(),
+        last_updated_at=datetime.now()
+    )
+
+# Standard actions for all tests in this module
+@pytest.fixture(scope="module", autouse=True)
+def setup_standard_actions(action_registry: TestActionRegistry, test_user_instance: UserInstanceData) -> None:
+    """
+    Register standard instance actions for all tests in this module.
+    The autouse=True ensures this runs automatically.
+    """
+    @action_registry.after()
+    def cleanup_instance(page: Page, backend_url: str, api_client: ApiClient) -> None:
+        """Cleanup the instance after each test"""
+        api_client.delete_instance(test_user_instance.hostname)
+
+class TestInstanceCreate:
+    def test_create_instance(self, page: Page, test_lifecycle: TestData, test_user_instance: UserInstanceData) -> None:
+        instance_list_page = InstanceListPage(page)
+        instance_list_page.navigate()
+        instance_list_page.click_create_instance()
+        instance_list_page.should_navigate_to_instance_create_page()
+
+        instance_create_page = InstanceCreatePage(page)
+        instance_create_page.choose_os_image(test_user_instance.os_type.os_image_name)
+        instance_create_page.choose_instance_plan(test_user_instance.instance_plan.instance_package_name)
+        instance_create_page.set_root_password(test_user_instance.root_password)
+        instance_create_page.set_hostname(test_user_instance.hostname)
+        instance_create_page.click_create_instance_button()
+        instance_create_page.toast.should_show_success_toast()
+        instance_create_page.should_navigate_to_instance_dashboard()

--- a/test/e2e/scenarios/test_landing_page.py
+++ b/test/e2e/scenarios/test_landing_page.py
@@ -3,12 +3,12 @@ from typing import Dict, Any
 from playwright.sync_api import Page, expect
 
 from ..pages.landing_page import LandingPage
-from ..conftest import TestActionRegistry, TestData
+from ..registry.actions import ActionRegistry, TestData
 from ..api.client import ApiClient
 
 # Standard actions for all tests in this module
 @pytest.fixture(scope="module", autouse=True)
-def setup_standard_actions(action_registry: TestActionRegistry) -> None:
+def setup_standard_actions(action_registry: ActionRegistry) -> None:
     """
     Register standard instance actions for all tests in this module.
     The autouse=True ensures this runs automatically.

--- a/test/e2e/scenarios/test_landing_page.py
+++ b/test/e2e/scenarios/test_landing_page.py
@@ -3,7 +3,33 @@ from typing import Dict, Any
 from playwright.sync_api import Page, expect
 
 from ..pages.landing_page import LandingPage
+from ..conftest import TestActionRegistry, TestData
+from ..api.client import ApiClient
 
+# Standard actions for all tests in this module
+@pytest.fixture(scope="module", autouse=True)
+def setup_standard_actions(action_registry: TestActionRegistry) -> None:
+    """
+    Register standard instance actions for all tests in this module.
+    The autouse=True ensures this runs automatically.
+    """
+    # Example using just page parameter
+    @action_registry.before()
+    def setup_page(page: Page) -> None:
+        """Simple action that only needs the page"""
+        print("Setting up page")
+    
+    # Example using multiple parameters
+    @action_registry.before()
+    def setup_api(page: Page, api_client: ApiClient, backend_url: str) -> None:
+        """Action that needs multiple parameters"""
+        print(f"Setting up API with backend URL: {backend_url}")
+    
+    # Example after action with different parameters
+    @action_registry.after()
+    def cleanup(api_client: ApiClient) -> None:
+        """After action that only needs api_client"""
+        print("Cleaning up after tests")
 
 class TestLandingPage:
     """
@@ -13,7 +39,7 @@ class TestLandingPage:
     """
     
     @pytest.mark.skip_auth
-    def test_landing_page_elements(self, page: Page) -> None:
+    def test_landing_page_elements(self, page: Page, test_lifecycle: TestData) -> None:
         """
         Test that all the main elements of the landing page are visible.
         


### PR DESCRIPTION
### Summary
![image](https://github.com/user-attachments/assets/d417aac5-2063-4f37-a1ec-8206902629f3)

Frontend:
- Add close button to the toast
- Improve toast dismiss reliability

Backend:
- Add `/user/admin/create` endpoint for testing user account(can be use for both user and admin)
- Make `/instance/create` endpoint deduct first payment
- Make `/instance/delete` endpoint remove subscription transaction(scheduled one)

Testing:
- Add BeforeEach and AfterEach functionality
- Add API client class
- Add better wait_for method
- Add instance create page test scenario